### PR TITLE
Move all copyright notices to NOTICE.txt and update the years

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,3 @@
+JDeli ImageIO Plugin
+
+Copyright 2021 - 2024 IDRsolutions

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ Got questions? You can contact us [here](https://idrsolutions.atlassian.net/serv
 
 ---
 
-
-Copyright 2023 IDRsolutions
-
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0

--- a/src/main/java/com/idrsolutions/BMPImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/BMPImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/BMPImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/BMPImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;

--- a/src/main/java/com/idrsolutions/HEICImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/HEICImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/HEICImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/HEICImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;

--- a/src/main/java/com/idrsolutions/JDeliImageReader.java
+++ b/src/main/java/com/idrsolutions/JDeliImageReader.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.JDeli;

--- a/src/main/java/com/idrsolutions/JDeliImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JDeliImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.imageio.ImageIOSupport;

--- a/src/main/java/com/idrsolutions/JDeliImageWriteParam.java
+++ b/src/main/java/com/idrsolutions/JDeliImageWriteParam.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;

--- a/src/main/java/com/idrsolutions/JDeliImageWriter.java
+++ b/src/main/java/com/idrsolutions/JDeliImageWriter.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.JDeli;

--- a/src/main/java/com/idrsolutions/JDeliImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/JDeliImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.imageio.ImageIOSupport;

--- a/src/main/java/com/idrsolutions/JDeliMetadata.java
+++ b/src/main/java/com/idrsolutions/JDeliMetadata.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 

--- a/src/main/java/com/idrsolutions/JPEG2000ImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JPEG2000ImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/JPEG2000ImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/JPEG2000ImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.imageio.ImageIOSupport;

--- a/src/main/java/com/idrsolutions/JPEGImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JPEGImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/JPEGImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/JPEGImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.imageio.ImageIOSupport;

--- a/src/main/java/com/idrsolutions/PDFImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/PDFImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;

--- a/src/main/java/com/idrsolutions/PNGImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/PNGImageReaderSpi.java
@@ -1,7 +1,3 @@
-
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/PNGImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/PNGImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;

--- a/src/main/java/com/idrsolutions/TIFFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/TIFFImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/TIFFImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/TIFFImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.imageio.ImageIOSupport;

--- a/src/main/java/com/idrsolutions/WEBPImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/WEBPImageReaderSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.ImageFormat;

--- a/src/main/java/com/idrsolutions/WEBPImageWriterSpi.java
+++ b/src/main/java/com/idrsolutions/WEBPImageWriterSpi.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) 1997-2023 IDRsolutions (https://www.idrsolutions.com)
- */
 package com.idrsolutions;
 
 import com.idrsolutions.image.encoder.OutputFormat;


### PR DESCRIPTION
I have updated the copyright and moved all mention of it to NOTICE.txt to make updating easier and match how the other GitHub projects handle it.