### PR TITLE
Use mark and reset to ensure stream is at the beginning after canDecodeInput()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.idrsolutions</groupId>
     <artifactId>jdeli-imageio${profile.identifier}</artifactId>
-    <version>3.1</version>
+    <version>3.2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 
     <properties>
         <finalName>${project.artifactId}</finalName>
-        <depVersion>2025.08</depVersion>
+        <depVersion>2026.01</depVersion>
         <depArtifact>jdeli</depArtifact>
 
         <!--An identifier used to change the artifactID for the daily, trial, and trial daily builds-->

--- a/src/main/java/com/idrsolutions/AVIFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/AVIFImageReaderSpi.java
@@ -28,7 +28,9 @@ public class AVIFImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.AVIF_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/BMPImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/BMPImageReaderSpi.java
@@ -29,7 +29,9 @@ public class BMPImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.BMP_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/DICOMImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/DICOMImageReaderSpi.java
@@ -31,7 +31,9 @@ public class DICOMImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.DICOM_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/EMFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/EMFImageReaderSpi.java
@@ -29,7 +29,9 @@ public class EMFImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.EMF_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/GIFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/GIFImageReaderSpi.java
@@ -29,7 +29,9 @@ public class GIFImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.GIF_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/HEICImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/HEICImageReaderSpi.java
@@ -29,7 +29,9 @@ public class HEICImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.HEIC_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/JPEG2000ImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JPEG2000ImageReaderSpi.java
@@ -23,7 +23,9 @@ public class JPEG2000ImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.JPEG2000_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/JPEGImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JPEGImageReaderSpi.java
@@ -33,7 +33,9 @@ public class JPEGImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.JPEG_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/JPEGXLImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/JPEGXLImageReaderSpi.java
@@ -23,7 +23,9 @@ public class JPEGXLImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.JPEGXL_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/PNGImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/PNGImageReaderSpi.java
@@ -33,7 +33,9 @@ public class PNGImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.PNG_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/PSDImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/PSDImageReaderSpi.java
@@ -29,7 +29,9 @@ public class PSDImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.PSD_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/TIFFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/TIFFImageReaderSpi.java
@@ -33,7 +33,9 @@ public class TIFFImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.TIFF_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/WEBPImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/WEBPImageReaderSpi.java
@@ -33,7 +33,9 @@ public class WEBPImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.WEBP_IMAGE);
         } else {

--- a/src/main/java/com/idrsolutions/WMFImageReaderSpi.java
+++ b/src/main/java/com/idrsolutions/WMFImageReaderSpi.java
@@ -29,7 +29,9 @@ public class WMFImageReaderSpi extends JDeliImageReaderSpi {
         if(isRegistered()) {
             final ImageInputStream input = (ImageInputStream) source;
             final byte[] b = new byte[140];
+            input.mark();
             input.read(b);
+            input.reset();
 
             return ImageTypeFinder.getImageType(b).equals(ImageFormat.WMF_IMAGE);
         } else {


### PR DESCRIPTION
When using ImageIO to read (For example: `ImageIO.read(new File("file.heic"));`), it calls `ImageReaderSpi#canDecodeInput(Object source)` for each Reader.  
Our implementation of this method for each JDeli reader will consume 140 bytes from the stream, which can lead to read errors when it gets to actually using the stream.

The documentation for this method specifies:
> It is important that the state of the object not be disturbed in order that other ImageReaderSpis can properly determine whether they are able to decode the object. In particular, if the source is an ImageInputStream, a mark/reset pair should be used to preserve the stream position

This PR adds these mark/reset pairs.